### PR TITLE
Adicionado dockerfile e docker-compose para api e db

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/node_modules
+/dist

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+#env file
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:lts-alpine AS build
+ADD package.json /app/package.json
+ADD package-lock.json /app/package-lock.json
+ADD nest-cli.json /app/nest-cli.json
+ADD tsconfig.json /app/tsconfig.json
+ADD tsconfig.build.json /app/tsconfig.build.json
+WORKDIR /app
+RUN ["npm", "install"]
+
+
+FROM build
+ADD src /app/src
+#DEVMODE
+CMD ["npm", "run", "start"]
+EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+
+  api:
+    build: 
+      dockerfile: Dockerfile
+      network: host
+    command: npm run start
+    restart: always
+    ports:
+      - "3000:3000"
+
+  api-db:
+    image: mongo:latest
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASS}


### PR DESCRIPTION
O projeto compila e roda usando `docker compose up`, o docker compose usa um arquivo `.env` pra definir valor padrão das variáveis de ambiente que estão entre `${}`, então só criar um ai com o que cada um quiser, o `.env` já foi adicionado no `.ignore`